### PR TITLE
Correctly override default Checker Framework behavior

### DIFF
--- a/src/edu/cmu/cs/glacier/GlacierAnnotatedTypeFactory.java
+++ b/src/edu/cmu/cs/glacier/GlacierAnnotatedTypeFactory.java
@@ -338,28 +338,6 @@ public class GlacierAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             visitedNodes.put(type, r);
             r = scanAndReduce(type.getSuperBound(), p, r);
             visitedNodes.put(type, r);
-            
-            
-			// For now, if any bound is immutable, the whole thing has to be immutable.
-			boolean foundImmutableBound = false;
-			if (type.getExtendsBound().getAnnotation(Immutable.class) != null) {
-				foundImmutableBound = true;
-			}
-			
-			if (type.getSuperBound().getAnnotation(Immutable.class) != null) {
-				foundImmutableBound = true;
-			}
-			
-			
-			if (foundImmutableBound) {
-				type.addAnnotation(Immutable.class);
-				assert(!type.hasAnnotation(Mutable.class));
-			}
-			else {
-				type.addAnnotation(Mutable.class);
-				assert(!type.hasAnnotation(Immutable.class));
-			}
-
             return r;
         }
         

--- a/src/edu/cmu/cs/glacier/GlacierTypeHierarchy.java
+++ b/src/edu/cmu/cs/glacier/GlacierTypeHierarchy.java
@@ -6,6 +6,7 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.DefaultTypeHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.javacutil.TypesUtils;
 
 import edu.cmu.cs.glacier.qual.Immutable;
 import edu.cmu.cs.glacier.qual.Mutable;
@@ -18,34 +19,21 @@ public class GlacierTypeHierarchy extends DefaultTypeHierarchy {
             boolean ignoreRawTypes, boolean invariantArrayComponents) {
     	super(checker, qualifierHierarchy, ignoreRawTypes, invariantArrayComponents, true);
     }
-    
-    @Override
-    protected boolean isPrimarySubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype,
-    		boolean annosCanBeEmpty) {
-    	Types types = this.checker.getProcessingEnvironment().getTypeUtils();
-    	if ((types.directSupertypes(supertype.getUnderlyingType())).size() == 0) {
-    		// Everything is a subtype of Object, regardless of annotations.
-    		return true;
-    	}
-    	else {
-    		final AnnotationMirror subtypeAnno   = subtype.getAnnotationInHierarchy(currentTop);
-    		final AnnotationMirror supertypeAnno = supertype.getAnnotationInHierarchy(currentTop);
 
-    		if (isAnnoSubtype(subtypeAnno, supertypeAnno, annosCanBeEmpty)) {
-    			return true;
-    		}
-    		
-    		// The subtype might be an immutable class that implements a mutable interface.
-    		// If so, we'll return true even though immutable is not a subtype of mutable by itself.
-    		if (subtype.hasAnnotation(Immutable.class) && supertype.hasAnnotation(Mutable.class)) {
-//    			System.out.println("checking " + subtype.getUnderlyingType() + " <: " + supertype.getUnderlyingType());
-    			// Check to make sure the subtype implements the supertype's interface.
-    			return types.isSubtype(subtype.getUnderlyingType(), supertype.getUnderlyingType());
-    		}
-    		else {
-    			return false;
-    		}
-    	}
-    }
-
+	@Override
+	public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype) {
+		if (TypesUtils.isObject(supertype.getUnderlyingType())){
+			// Everything is a subtype of Object, regardless of annotations.
+			return true;
+		}
+		return super.isSubtype(subtype, supertype);
+	}
+	@Override
+	public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top) {
+		if (TypesUtils.isObject(supertype.getUnderlyingType())){
+			// Everything is a subtype of Object, regardless of annotations.
+			return true;
+		}
+		return super.isSubtype(subtype, supertype, top);
+	}
 }

--- a/tests/glacier/InvalidTypeArguments.java
+++ b/tests/glacier/InvalidTypeArguments.java
@@ -1,0 +1,33 @@
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import edu.cmu.cs.glacier.qual.Immutable;
+import edu.cmu.cs.glacier.qual.Mutable;
+
+public class InvalidTypeArguments {
+    interface MutableObject {}
+    @Immutable interface ImmutableObject {}
+
+    class Generic<T> {}
+    Generic<MutableObject> mutableObjectGeneric;
+    Generic<ImmutableObject> immutableObjectGeneric;
+
+    class ImmutableGeneric<@Immutable T extends @Immutable Object>{}
+    //:: error: (type.argument.type.incompatible)
+    ImmutableGeneric<MutableObject> mutableObjectImmutableGeneric;
+    ImmutableGeneric<ImmutableObject> immutableObjectImmutableGeneric;
+
+    class MutableGeneric<@Mutable T>{}
+    MutableGeneric<MutableObject> mutableObjectMutableGeneric;
+    //:: error: (type.argument.type.incompatible)
+    MutableGeneric<ImmutableObject> immutableObjectMutableGeneric;
+
+    public class UnmodifiableCollection {
+        public Iterator<MutableObject> getCellIterator() {
+            Collection<MutableObject> cellCollection = null;
+            Collections.unmodifiableCollection(cellCollection);
+            return Collections.unmodifiableCollection(cellCollection).iterator();
+        }
+    }
+}


### PR DESCRIPTION
I would also recommend replacing 

```
(types.directSupertypes(atm.getUnderlyingType())).size() == 0
```

with

```
TypesUtils.isObject(atm.getUnderlyingType())
```

every where in the code.

`ant glacier-tests` still passes, but let me know if you have any examples that are no longer behaving as expected.
