### PR TITLE
Checker framework 2.3.2 fixes

### DIFF
--- a/src/edu/cmu/cs/glacier/GlacierTypeValidator.java
+++ b/src/edu/cmu/cs/glacier/GlacierTypeValidator.java
@@ -50,7 +50,7 @@ public class GlacierTypeValidator extends BaseTypeValidator {
     @Override
     public Void visitDeclared(AnnotatedDeclaredType type, Tree tree) {
     	if (type.hasAnnotation(GlacierBottom.class)) {
-    		reportError(type, tree);
+    		reportInvalidAnnotationsOnUse(type, tree);
     	}
     	else {
     		return super.visitDeclared(type, tree);

--- a/src/edu/cmu/cs/glacier/GlacierVisitor.java
+++ b/src/edu/cmu/cs/glacier/GlacierVisitor.java
@@ -63,7 +63,7 @@ public class GlacierVisitor extends BaseTypeVisitor<GlacierAnnotatedTypeFactory>
 		boolean foundImmutable = false;
 		
 		List <? extends AnnotationTree> annotations = modifiers.getAnnotations();
-		for (AnnotationMirror a : InternalUtils.annotationsFromTypeAnnotationTrees(annotations)) {
+		for (AnnotationMirror a : TreeUtils.annotationsFromTypeAnnotationTrees(annotations)) {
 	        if (AnnotationUtils.areSameByClass(a,modifier)) {
 	        	foundImmutable = true;
 	        }

--- a/src/edu/cmu/cs/glacier/qual/Immutable.java
+++ b/src/edu/cmu/cs/glacier/qual/Immutable.java
@@ -4,7 +4,7 @@ import java.lang.annotation.Target;
 
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.ImplicitFor;
-import javax.lang.model.type.TypeKind;
+import org.checkerframework.framework.qual.TypeKind;
 
 import java.lang.annotation.ElementType;
 

--- a/tests/glacier/ConflictingAnnotations.java
+++ b/tests/glacier/ConflictingAnnotations.java
@@ -16,18 +16,18 @@ interface MutableInterface {
 }
 
 public class ConflictingAnnotations {
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     @MaybeMutable ImmutClass o1;
 
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     @Immutable MutableClass o2;
 
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     @Immutable DefaultMutableClass o3;
 
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     @MaybeMutable ImmutInterface i1;
 
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     @Immutable MutableInterface i2;
 }

--- a/tests/glacier/ConflictingAnnotations.java
+++ b/tests/glacier/ConflictingAnnotations.java
@@ -16,18 +16,18 @@ interface MutableInterface {
 }
 
 public class ConflictingAnnotations {
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     @MaybeMutable ImmutClass o1;
 
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     @Immutable MutableClass o2;
 
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     @Immutable DefaultMutableClass o3;
 
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     @MaybeMutable ImmutInterface i1;
 
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     @Immutable MutableInterface i2;
 }

--- a/tests/glacier/ConstructorAssignment.java
+++ b/tests/glacier/ConstructorAssignment.java
@@ -10,7 +10,7 @@ public @Immutable class ConstructorAssignment {
     }
 
     void setX() {
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	x = 5;
     }
 }
@@ -18,7 +18,7 @@ public @Immutable class ConstructorAssignment {
 class OtherClass {
     OtherClass() {
 	ConstructorAssignment c = new ConstructorAssignment();
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	c.x = 6;
     }
 }

--- a/tests/glacier/EqualsTest.java
+++ b/tests/glacier/EqualsTest.java
@@ -13,7 +13,7 @@ import edu.cmu.cs.glacier.qual.*;
 
 class EqualsTest2 {
 	@Override
-	//::error: (override.param.invalid)
+	// ::error: (override.param.invalid)
 	public boolean equals(@Immutable Object obj) {
 		if (this == obj)
 			return true;

--- a/tests/glacier/EqualsTest.java
+++ b/tests/glacier/EqualsTest.java
@@ -3,7 +3,6 @@ package edu.cmu.cs.glacier.tests;
 import edu.cmu.cs.glacier.qual.*;
 
 @Immutable public class EqualsTest {
-	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
@@ -12,7 +11,6 @@ import edu.cmu.cs.glacier.qual.*;
 }
 
 class EqualsTest2 {
-	@Override
 	// ::error: (override.param.invalid)
 	public boolean equals(@Immutable Object obj) {
 		if (this == obj)

--- a/tests/glacier/FontImpl.java
+++ b/tests/glacier/FontImpl.java
@@ -8,13 +8,13 @@ import edu.cmu.cs.glacier.qual.*;
 }
 
 // ::error: (glacier.subclass.mutable)
-class ColorImpl extends AbstractColorAdv {
+class FI_ColorImpl extends AbstractColorAdv {
 	// Arguably it would be preferable for this to not be an error.
 	// ::error: (assignment.type.incompatible)
-	public static final AbstractColorAdv BLACK = new ColorImpl("#000000");
-	
-	
-	ColorImpl(String fontColor) {
+	public static final AbstractColorAdv BLACK = new FI_ColorImpl("#000000");
+
+
+	FI_ColorImpl(String fontColor) {
 		
 	}
 }
@@ -23,10 +23,10 @@ public class FontImpl {
 	FontImpl(String fontColor) {
 		// Arguably it would be preferable for this to not be an error.
 		// ::error: (assignment.type.incompatible)
-		SColor a = new ColorImpl(fontColor);
+		SColor a = new FI_ColorImpl(fontColor);
 		
 		// Arguably it would be preferable for this to not be an error either.
-		// ::error: (type.invalid)
-		SColor c = fontColor != null ? new ColorImpl(fontColor) : null;
+		// ::error: (type.invalid.annotations.on.use)
+		SColor c = fontColor != null ? new FI_ColorImpl(fontColor) : null;
 	}
 }

--- a/tests/glacier/FontImpl.java
+++ b/tests/glacier/FontImpl.java
@@ -7,10 +7,10 @@ import edu.cmu.cs.glacier.qual.*;
 @Immutable abstract class AbstractColorAdv implements SColor {
 }
 
-//::error: (glacier.subclass.mutable)
+// ::error: (glacier.subclass.mutable)
 class ColorImpl extends AbstractColorAdv {
 	// Arguably it would be preferable for this to not be an error.
-	//::error: (assignment.type.incompatible)
+	// ::error: (assignment.type.incompatible)
 	public static final AbstractColorAdv BLACK = new ColorImpl("#000000");
 	
 	
@@ -22,11 +22,11 @@ class ColorImpl extends AbstractColorAdv {
 public class FontImpl {
 	FontImpl(String fontColor) {
 		// Arguably it would be preferable for this to not be an error.
-		//::error: (assignment.type.incompatible)
+		// ::error: (assignment.type.incompatible)
 		SColor a = new ColorImpl(fontColor);
 		
 		// Arguably it would be preferable for this to not be an error either.
-		//::error: (type.invalid)
+		// ::error: (type.invalid)
 		SColor c = fontColor != null ? new ColorImpl(fontColor) : null;
 	}
 }

--- a/tests/glacier/ImmutableArray.java
+++ b/tests/glacier/ImmutableArray.java
@@ -6,10 +6,10 @@ import edu.cmu.cs.glacier.qual.Immutable;
     private String @Immutable [] _strings;
 
     // Immutable array of mutable objects is mutable.
-    //::error: (glacier.mutable.array.invalid)
+    // ::error: (glacier.mutable.array.invalid)
     private java.util.Date @Immutable [] _dates;
 
     // MaybeMutable array of primitives is mutable.
-    //::error: (glacier.mutable.wholearray.invalid)
+    // ::error: (glacier.mutable.wholearray.invalid)
     private int [] _ints;
 }

--- a/tests/glacier/ImmutableClassMutableInterface.java
+++ b/tests/glacier/ImmutableClassMutableInterface.java
@@ -1,9 +1,9 @@
 import edu.cmu.cs.glacier.qual.Immutable;
 
-interface MutableInterface {};
+interface ICMI_MutableInterface {};
 
-@Immutable public class ImmutableClassMutableInterface implements MutableInterface {
-    public static void bar(MutableInterface m) { };
+@Immutable public class ImmutableClassMutableInterface implements ICMI_MutableInterface {
+    public static void bar(ICMI_MutableInterface m) { };
 
     public static void foo() {
 	ImmutableClassMutableInterface x = null;

--- a/tests/glacier/ImmutableConstructorInMutableClass.java
+++ b/tests/glacier/ImmutableConstructorInMutableClass.java
@@ -5,7 +5,7 @@ import edu.cmu.cs.glacier.qual.Immutable;
 
 
 public class ImmutableConstructorInMutableClass { 
-	// :: error: (type.invalid)
+	// :: error: (type.invalid.annotations.on.use)
 	@Immutable public ImmutableConstructorInMutableClass() {
 	}
 	

--- a/tests/glacier/ImmutableConstructorInMutableClass.java
+++ b/tests/glacier/ImmutableConstructorInMutableClass.java
@@ -5,7 +5,7 @@ import edu.cmu.cs.glacier.qual.Immutable;
 
 
 public class ImmutableConstructorInMutableClass { 
-	//:: error: (type.invalid)
+	// :: error: (type.invalid)
 	@Immutable public ImmutableConstructorInMutableClass() {
 	}
 	

--- a/tests/glacier/ImmutablePerson.java
+++ b/tests/glacier/ImmutablePerson.java
@@ -35,7 +35,7 @@ class Person {
 
 @Immutable public class ImmutablePerson {
 	// Date is mutable
-	//:: error: glacier.mutable.invalid
+	// :: error: glacier.mutable.invalid
 	Date birthdate;
 	
 	public ImmutablePerson() {

--- a/tests/glacier/ImmutablePrimitiveContainer.java
+++ b/tests/glacier/ImmutablePrimitiveContainer.java
@@ -5,7 +5,7 @@ public class ImmutablePrimitiveContainer {
     int x;
 
     public void setX(int x) {
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	this.x = x;
     }
 }

--- a/tests/glacier/IncorrectUsage.java
+++ b/tests/glacier/IncorrectUsage.java
@@ -11,12 +11,12 @@ import edu.cmu.cs.glacier.qual.*;
 		
 	}
 	
-	//::error: (type.invalid)
+	// ::error: (type.invalid)
 	public void badMethod(@MaybeMutable IncorrectUsage this) {
 		
 	}
 	
-	//::error: (type.invalid)
+	// ::error: (type.invalid)
 	public void badMethod2(@MaybeMutable IncorrectUsage obj) {
 		
 	}
@@ -32,12 +32,12 @@ class IncorrectUsage2 {
 		
 	}
 	
-	//::error: (type.invalid)
+	// ::error: (type.invalid)
 	public void badMethod(@Immutable IncorrectUsage2 this) {
 		
 	}
 	
-	//::error: (type.invalid)
+	// ::error: (type.invalid)
 	public void badMethod2(@Immutable IncorrectUsage2 obj) {
 		
 	}

--- a/tests/glacier/IncorrectUsage.java
+++ b/tests/glacier/IncorrectUsage.java
@@ -11,12 +11,12 @@ import edu.cmu.cs.glacier.qual.*;
 		
 	}
 	
-	// ::error: (type.invalid)
+	// ::error: (type.invalid.annotations.on.use)
 	public void badMethod(@MaybeMutable IncorrectUsage this) {
 		
 	}
 	
-	// ::error: (type.invalid)
+	// ::error: (type.invalid.annotations.on.use)
 	public void badMethod2(@MaybeMutable IncorrectUsage obj) {
 		
 	}
@@ -32,12 +32,12 @@ class IncorrectUsage2 {
 		
 	}
 	
-	// ::error: (type.invalid)
+	// ::error: (type.invalid.annotations.on.use)
 	public void badMethod(@Immutable IncorrectUsage2 this) {
 		
 	}
 	
-	// ::error: (type.invalid)
+	// ::error: (type.invalid.annotations.on.use)
 	public void badMethod2(@Immutable IncorrectUsage2 obj) {
 		
 	}

--- a/tests/glacier/InterfaceField.java
+++ b/tests/glacier/InterfaceField.java
@@ -5,7 +5,7 @@ interface AnInterface {};
 @Immutable interface ImmutableInterface extends AnInterface {};
 
 @Immutable public class InterfaceField {
-    //::error: (glacier.mutable.invalid)
+    // ::error: (glacier.mutable.invalid)
     AnInterface o;
     ImmutableInterface o2;
 }

--- a/tests/glacier/InterfaceField.java
+++ b/tests/glacier/InterfaceField.java
@@ -1,11 +1,11 @@
 import edu.cmu.cs.glacier.qual.Immutable;
 
-interface AnInterface {};
+interface IF_AnInterface {};
 
-@Immutable interface ImmutableInterface extends AnInterface {};
+@Immutable interface IF_ImmutableInterface extends IF_AnInterface {};
 
 @Immutable public class InterfaceField {
     // ::error: (glacier.mutable.invalid)
-    AnInterface o;
-    ImmutableInterface o2;
+    IF_AnInterface o;
+    IF_ImmutableInterface o2;
 }

--- a/tests/glacier/InvalidAnnotations.java
+++ b/tests/glacier/InvalidAnnotations.java
@@ -1,9 +1,9 @@
 import edu.cmu.cs.glacier.qual.*;
 
-//::error: (type.invalid)
+// ::error: (type.invalid)
 @GlacierBottom class InvalidBottom {};
 
 public class InvalidAnnotations {
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     InvalidBottom b;
 }

--- a/tests/glacier/InvalidAnnotations.java
+++ b/tests/glacier/InvalidAnnotations.java
@@ -1,9 +1,9 @@
 import edu.cmu.cs.glacier.qual.*;
 
-// ::error: (type.invalid)
+// ::error: (type.invalid.annotations.on.use)
 @GlacierBottom class InvalidBottom {};
 
 public class InvalidAnnotations {
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     InvalidBottom b;
 }

--- a/tests/glacier/InvalidAssignment.java
+++ b/tests/glacier/InvalidAssignment.java
@@ -11,19 +11,19 @@ public @Immutable class InvalidAssignment {
 	}
 	
 	String s;
-	//:: error: glacier.mutable.invalid
+	// :: error: glacier.mutable.invalid
 	Calendar c;
-	//:: error: glacier.mutable.invalid
+	// :: error: glacier.mutable.invalid
 	Inner i;
 	int x;
 	
 	public void setString(String s) {
-		//:: error: glacier.assignment
+		// :: error: glacier.assignment
 		this.s = s;
 	}
 	
 	public void setX(int x) {
-		//:: error: glacier.assignment
+		// :: error: glacier.assignment
 		this.x = x;
 	}
 	
@@ -40,7 +40,7 @@ class AnotherClass {
     void aMethod() {
 	InvalidAssignment i = new InvalidAssignment();
     
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	i.s = "hello";
     }
 }

--- a/tests/glacier/InvalidImmutableInterfaceClass.java
+++ b/tests/glacier/InvalidImmutableInterfaceClass.java
@@ -7,7 +7,7 @@ import java.lang.Cloneable;
 @Immutable interface ImmutableInterface {
 }
 
-//:: error: glacier.interface.immutable
+// :: error: glacier.interface.immutable
 public class InvalidImmutableInterfaceClass implements Cloneable, ImmutableInterface {
 
 }

--- a/tests/glacier/InvalidImmutableInterfaceClass.java
+++ b/tests/glacier/InvalidImmutableInterfaceClass.java
@@ -4,10 +4,10 @@ import edu.cmu.cs.glacier.qual.Immutable;
 
 import java.lang.Cloneable;
 
-@Immutable interface ImmutableInterface {
+@Immutable interface IIIC_ImmutableInterface {
 }
 
 // :: error: glacier.interface.immutable
-public class InvalidImmutableInterfaceClass implements Cloneable, ImmutableInterface {
+public class InvalidImmutableInterfaceClass implements Cloneable, IIIC_ImmutableInterface {
 
 }

--- a/tests/glacier/InvalidTypeArguments.java
+++ b/tests/glacier/InvalidTypeArguments.java
@@ -14,19 +14,19 @@ public class InvalidTypeArguments {
     Generic<ImmutableObject> immutableObjectGeneric;
 
 	class BogusImmutableGeneric<@Immutable T>{}
-	//:: error: (type.argument.type.incompatible)
+	// :: error: (type.argument.type.incompatible)
 	BogusImmutableGeneric<MutableObject> mutableObjectBogusImmutableGeneric;
 	BogusImmutableGeneric<ImmutableObject> immutableObjectBogusImmutableGeneric;
 		
 
     class ImmutableGeneric<@Immutable T extends @Immutable Object>{}
-    //:: error: (type.argument.type.incompatible)
+    // :: error: (type.argument.type.incompatible)
     ImmutableGeneric<MutableObject> mutableObjectImmutableGeneric;
     ImmutableGeneric<ImmutableObject> immutableObjectImmutableGeneric;
 
     class MutableGeneric<@MaybeMutable T>{}
     MutableGeneric<MutableObject> mutableObjectMutableGeneric;
-    //:: error: (type.argument.type.incompatible)
+    // :: error: (type.argument.type.incompatible)
     MutableGeneric<ImmutableObject> immutableObjectMutableGeneric;
 
     public class UnmodifiableCollection {

--- a/tests/glacier/MutableClassCantHaveImmutableSubclass.java
+++ b/tests/glacier/MutableClassCantHaveImmutableSubclass.java
@@ -34,5 +34,5 @@ class UnsafeAbstractSuperclass2 {
     final Immut i = null;
 }
 
-// ::error: (glacier.mutablemember)
+// ::error: (glacier.nonfinalmember) ::error: (glacier.mutablemember)
 @Immutable class Immut4 extends UnsafeAbstractSuperclass2 { };

--- a/tests/glacier/MutableClassCantHaveImmutableSubclass.java
+++ b/tests/glacier/MutableClassCantHaveImmutableSubclass.java
@@ -5,7 +5,7 @@ class Mut {
     int y = 3;
 }
 
-//::error: (glacier.nonfinalmember)
+// ::error: (glacier.nonfinalmember)
 @Immutable class Immut extends Mut { }
 
 class SafeAbstractSuperclass {
@@ -22,7 +22,7 @@ class UnsafeAbstractSuperclass {
     final Immut i = null;
 }
 
-//::error: (glacier.nonfinalmember)
+// ::error: (glacier.nonfinalmember)
 @Immutable class Immut3 extends UnsafeAbstractSuperclass { };
 
 
@@ -34,5 +34,5 @@ class UnsafeAbstractSuperclass2 {
     final Immut i = null;
 }
 
-//::error: (glacier.mutablemember)
+// ::error: (glacier.mutablemember)
 @Immutable class Immut4 extends UnsafeAbstractSuperclass2 { };

--- a/tests/glacier/NullAssignment.java
+++ b/tests/glacier/NullAssignment.java
@@ -1,6 +1,6 @@
 import edu.cmu.cs.glacier.qual.Immutable;
 
-interface AnInterface {};
+interface NA_AnInterface {};
 
 
 public class NullAssignment {
@@ -8,7 +8,7 @@ public class NullAssignment {
     }
     
     public void foo() {
-	AnInterface i = null;
+	NA_AnInterface i = null;
 	takeObj(i);
     }
 }

--- a/tests/glacier/PlainObjects.java
+++ b/tests/glacier/PlainObjects.java
@@ -11,7 +11,7 @@ class PlainObjects {
 
 	takeObject(o2);
 
-	//::error: (argument.type.incompatible)
+	// ::error: (argument.type.incompatible)
 	takeImmutableObject(o1);
     }
 }

--- a/tests/glacier/ReadOnlyClass.java
+++ b/tests/glacier/ReadOnlyClass.java
@@ -11,7 +11,7 @@ class ReadOnlyMethodClass {
 
     int @ReadOnly [] readOnlyIntArray;
     
-    // ::error: (type.invalid)
+    // ::error: (type.invalid.annotations.on.use)
     void takeReadOnlyString(@ReadOnly String foo) {}
     void takeReadOnlyArray(String @ReadOnly [] foo) {
 	// ::error: (glacier.assignment.array)

--- a/tests/glacier/ReadOnlyClass.java
+++ b/tests/glacier/ReadOnlyClass.java
@@ -2,7 +2,7 @@ import edu.cmu.cs.glacier.qual.*;
 import java.lang.String;
 
 // Classes can't be annotated ReadOnly in their declarations; @ReadOnly is only for method parameters.
-//::error: (glacier.readonly.class)
+// ::error: (glacier.readonly.class)
 @ReadOnly public class ReadOnlyClass {
 }
 
@@ -11,15 +11,15 @@ class ReadOnlyMethodClass {
 
     int @ReadOnly [] readOnlyIntArray;
     
-    //::error: (type.invalid)
+    // ::error: (type.invalid)
     void takeReadOnlyString(@ReadOnly String foo) {}
     void takeReadOnlyArray(String @ReadOnly [] foo) {
-	//::error: (glacier.assignment.array)
+	// ::error: (glacier.assignment.array)
 	foo[0] = "Hello, world!";
     }
 
     void takeImmutableArray(String @Immutable [] foo) {
-	//::error: (glacier.assignment.array)
+	// ::error: (glacier.assignment.array)
 	foo[0] = "Hello, world!";
     }
 }

--- a/tests/glacier/StaticAssignment.java
+++ b/tests/glacier/StaticAssignment.java
@@ -5,12 +5,12 @@ public class StaticAssignment {
     public static int GLOBAL = 1; // OK, no error here
 
     StaticAssignment() {
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	GLOBAL = 2;
     }
     
     public void setStatics () {
-	//::error: (glacier.assignment)
+	// ::error: (glacier.assignment)
 	GLOBAL = 42;
     }
     

--- a/tests/glacier/Subclassing.java
+++ b/tests/glacier/Subclassing.java
@@ -11,5 +11,5 @@ class MutSubclass extends Subclassing { };
 @Immutable class ImmutableSuper { };
 @Immutable class ImmutableSub extends ImmutableSuper { };
 
-//::error: (glacier.subclass.mutable)
+// ::error: (glacier.subclass.mutable)
 class InvalidMutableSub extends ImmutableSuper { };

--- a/tests/glacier/TransitivityError.java
+++ b/tests/glacier/TransitivityError.java
@@ -8,7 +8,7 @@ class Inner {
 }
 
 public @Immutable class TransitivityError {
-	//:: error: glacier.mutable.invalid
+	// :: error: glacier.mutable.invalid
 	Inner i;
 	
 	public TransitivityError() {

--- a/tests/glacier/TransitivityError.java
+++ b/tests/glacier/TransitivityError.java
@@ -3,13 +3,13 @@ package edu.cmu.cs.glacier.tests;
 import edu.cmu.cs.glacier.qual.Immutable;
 
 
-class Inner { 
+class TE_Inner { 
 	int x;
 }
 
 public @Immutable class TransitivityError {
 	// :: error: glacier.mutable.invalid
-	Inner i;
+	TE_Inner i;
 	
 	public TransitivityError() {
 	}

--- a/tests/glacier/TypeParameter.java
+++ b/tests/glacier/TypeParameter.java
@@ -2,19 +2,19 @@ import edu.cmu.cs.glacier.qual.Immutable;
 
 class E { } // Note same name as type parameter, but mutable class.
 
-@Immutable class Superclass<E> {
+@Immutable class TP_Superclass<E> {
     private E aField; // Should be OK because we'll make sure E is instantiated with an immutable type. This E is the type parameter, not the class above.
     void aMethod() {
 
     }
 }
 
-@Immutable public class TypeParameter<E> extends Superclass<E> {
-    private Superclass<? extends E> s;
-    private Superclass<? extends String> t;
+@Immutable public class TypeParameter<E> extends TP_Superclass<E> {
+    private TP_Superclass<? extends E> s;
+    private TP_Superclass<? extends String> t;
 
     // ::error: (glacier.typeparameter.mutable)
-    private Superclass<? extends java.util.Date> u;
+    private TP_Superclass<? extends java.util.Date> u;
     
     void aMethod() {
 

--- a/tests/glacier/TypeParameter.java
+++ b/tests/glacier/TypeParameter.java
@@ -13,7 +13,7 @@ class E { } // Note same name as type parameter, but mutable class.
     private Superclass<? extends E> s;
     private Superclass<? extends String> t;
 
-    //::error: (glacier.typeparameter.mutable)
+    // ::error: (glacier.typeparameter.mutable)
     private Superclass<? extends java.util.Date> u;
     
     void aMethod() {
@@ -24,6 +24,6 @@ class E { } // Note same name as type parameter, but mutable class.
 @Immutable class Test {
     TypeParameter <String> t1 = null; // OK
 
-    //::error: (glacier.typeparameter.mutable)
+    // ::error: (glacier.typeparameter.mutable)
     TypeParameter <java.util.Date> t2 = null;
 }

--- a/tests/glacier/UnmodifiableList.java
+++ b/tests/glacier/UnmodifiableList.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 class ListProcessor {
     static <T> List<T> process(List<? extends T> c) {
-    //::warning: [unchecked] unchecked cast
+    // ::warning: [unchecked] unchecked cast
 	return (List<T>)c;
     }
 }

--- a/tests/glacier/ValidImmutableInterfaceClass.java
+++ b/tests/glacier/ValidImmutableInterfaceClass.java
@@ -3,9 +3,9 @@ package edu.cmu.cs.glacier.tests;
 import edu.cmu.cs.glacier.qual.Immutable;
 
 
-@Immutable interface ImmutableInterface {
+@Immutable interface VIIC_ImmutableInterface {
 }
 
-public @Immutable class ValidImmutableInterfaceClass implements ImmutableInterface {
+public @Immutable class ValidImmutableInterfaceClass implements VIIC_ImmutableInterface {
 
 }

--- a/tests/src/tests/GlacierTest.java
+++ b/tests/src/tests/GlacierTest.java
@@ -1,26 +1,13 @@
 package tests;
 
-import static org.checkerframework.framework.test.TestConfigurationBuilder.buildDefaultConfiguration;
-
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
-
-import org.checkerframework.framework.test.CheckerFrameworkTest;
-import org.junit.Test;
+import org.checkerframework.framework.test.CheckerFrameworkPerFileTest;
+import org.checkerframework.framework.test.PerFileSuite;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.junit.runner.notification.Failure;
-import org.junit.runners.*;
-
-
-import org.checkerframework.framework.test.TestConfiguration;
-import org.checkerframework.framework.test.TestUtilities;
-import org.checkerframework.framework.test.TypecheckExecutor;
-import org.checkerframework.framework.test.TypecheckResult;
 import org.junit.runners.Parameterized.Parameters;
 
-import org.checkerframework.framework.test.TestSuite;
+import java.io.File;
 /**
  * JUnit tests for the Glacier Checker -- testing -AskipDefs command-line argument.
  */
@@ -73,8 +60,8 @@ public class GlacierTest {
 		}
 	}
 	
-	@RunWith(TestSuite.class)
-	public static class GlacierCheckerTests extends CheckerFrameworkTest {
+	@RunWith(PerFileSuite.class)
+	public static class GlacierCheckerTests extends CheckerFrameworkPerFileTest {
 	    public GlacierCheckerTests(File testFile) {
 	        super(testFile, edu.cmu.cs.glacier.GlacierChecker.class, "glacier", "-Anomsgtext");
 	    }


### PR DESCRIPTION
Hi Michael,

I tried out Glacier after you mentioned in to me at Dagstuhl.  I'm using checker framework 2.3.2 so I had to make some updates to Glacier to get it compiling against 2.3.2.  Those changes are fairly trivial I think, but getting the Glacier tests working with 2.3.2 involves some more changes.  See the commit comment on the last commit (35d2a3d) for a detailed explanation, so you can judge if you think it should be done differently.  After all these changes, Glacier compiles and passes all tests with checker-framework 2.3.2.

Thanks,

Neil.